### PR TITLE
fix: RecognizerResultState serialization

### DIFF
--- a/BlinkID/lib/recognizer.dart
+++ b/BlinkID/lib/recognizer.dart
@@ -37,12 +37,12 @@ class Recognizer {
 /// Possible states of the Recognizer's result
 enum RecognizerResultState {
   /// Recognizer result is empty
-  empty,
+  @JsonValue(0) empty,
   /// Recognizer result contains some values, but is incomplete or it contains all values, but some are uncertain
-  uncertain,
+  @JsonValue(1) uncertain,
   /// Recognizer result contains all required values
-  valid,
-  stageValid
+  @JsonValue(2) valid,
+  @JsonValue(3) stageValid
 }
 
 /// Base class for all recognizer's result objects.

--- a/BlinkID/lib/recognizer.g.dart
+++ b/BlinkID/lib/recognizer.g.dart
@@ -55,10 +55,10 @@ K _$enumDecode<K, V>(
 }
 
 const _$RecognizerResultStateEnumMap = {
-  RecognizerResultState.empty: 'empty',
-  RecognizerResultState.uncertain: 'uncertain',
-  RecognizerResultState.valid: 'valid',
-  RecognizerResultState.stageValid: 'stageValid',
+  RecognizerResultState.empty: 0,
+  RecognizerResultState.uncertain: 1,
+  RecognizerResultState.valid: 2,
+  RecognizerResultState.stageValid: 3,
 };
 
 RecognizerCollection _$RecognizerCollectionFromJson(Map<String, dynamic> json) {


### PR DESCRIPTION
These changes fix `RecognizerResult.fromJson` function, as enums are serialized by their `ordinal` value.

See [`SerializationUtils.addCommonRecognizerResultData`](https://github.com/BlinkID/blinkid-flutter/blob/8a0a352ca70b8b23933363945f92a22afd58a0af/BlinkID/android/src/main/java/com/microblink/flutter/SerializationUtils.java#L29).