### PR TITLE
refactor: Use explicitToJson parameter for json_serializable

### DIFF
--- a/BlinkID/build.yaml
+++ b/BlinkID/build.yaml
@@ -1,0 +1,6 @@
+targets:
+  $default:
+    builders:
+      json_serializable:
+        options:
+          explicit_to_json: true

--- a/BlinkID/lib/microblink_scanner.dart
+++ b/BlinkID/lib/microblink_scanner.dart
@@ -10,7 +10,6 @@ export 'package:blinkid_flutter/overlay_settings.dart';
 export 'package:blinkid_flutter/types.dart';
 
 class MicroblinkScanner {
-
   static const MethodChannel _channel = const MethodChannel('blinkid_scanner');
 
   static const String METHOD_SCAN_WITH_CAMERA = 'scanWithCamera';
@@ -22,24 +21,28 @@ class MicroblinkScanner {
   static const String ARG_LICENSEE = 'licensee';
   static const String ARG_SHOW_LICENSE_WARNING = 'showTrialLicenseWarning';
 
-  static Future<List<RecognizerResult>> scanWithCamera(RecognizerCollection collection, OverlaySettings overlaySettings, String license) async {
-    var jsonResults = jsonDecode(await _channel.invokeMethod(
-      METHOD_SCAN_WITH_CAMERA,
-      {
-        ARG_RECOGNIZER_COLLECTION: jsonDecode(jsonEncode(collection)),
-        ARG_OVERLAY_SETTINGS: jsonDecode(jsonEncode(overlaySettings)),
-        ARG_LICENSE: {
-          ARG_LICENSE_KEY: license
-        }
-      })
+  static Future<List<RecognizerResult>> scanWithCamera(
+    RecognizerCollection collection,
+    OverlaySettings overlaySettings,
+    String license,
+  ) async {
+    final jsonResults = jsonDecode(
+      await _channel.invokeMethod(
+        METHOD_SCAN_WITH_CAMERA,
+        {
+          ARG_RECOGNIZER_COLLECTION: collection.toJson(),
+          ARG_OVERLAY_SETTINGS: overlaySettings.toJson(),
+          ARG_LICENSE: {ARG_LICENSE_KEY: license}
+        },
+      ),
     );
 
     if (jsonResults == null) return List.empty();
 
-    var results = [];
+    final results = [];
     for (int i = 0; i < jsonResults.length; ++i) {
-      var map = Map<String, dynamic>.from(jsonResults[i]);
-      var result = collection.recognizerArray[i].createResultFromNative(map);
+      final map = Map<String, dynamic>.from(jsonResults[i]);
+      final result = collection.recognizerArray[i].createResultFromNative(map);
       if (result.resultState != RecognizerResultState.empty) {
         results.add(result);
       }
@@ -47,5 +50,4 @@ class MicroblinkScanner {
 
     return List<RecognizerResult>.from(results);
   }
-
 }

--- a/BlinkID/lib/recognizer.g.dart
+++ b/BlinkID/lib/recognizer.g.dart
@@ -74,7 +74,8 @@ RecognizerCollection _$RecognizerCollectionFromJson(Map<String, dynamic> json) {
 Map<String, dynamic> _$RecognizerCollectionToJson(
         RecognizerCollection instance) =>
     <String, dynamic>{
-      'recognizerArray': instance.recognizerArray,
+      'recognizerArray':
+          instance.recognizerArray.map((e) => e.toJson()).toList(),
       'allowMultipleResults': instance.allowMultipleResults,
       'milisecondsBeforeTimeout': instance.milisecondsBeforeTimeout,
     };

--- a/BlinkID/lib/recognizers/blink_id_combined_recognizer.g.dart
+++ b/BlinkID/lib/recognizers/blink_id_combined_recognizer.g.dart
@@ -47,10 +47,10 @@ Map<String, dynamic> _$BlinkIdCombinedRecognizerToJson(
       'faceImageDpi': instance.faceImageDpi,
       'fullDocumentImageDpi': instance.fullDocumentImageDpi,
       'fullDocumentImageExtensionFactors':
-          instance.fullDocumentImageExtensionFactors,
+          instance.fullDocumentImageExtensionFactors.toJson(),
       'maxAllowedMismatchesPerField': instance.maxAllowedMismatchesPerField,
       'paddingEdge': instance.paddingEdge,
-      'recognitionModeFilter': instance.recognitionModeFilter,
+      'recognitionModeFilter': instance.recognitionModeFilter.toJson(),
       'returnFaceImage': instance.returnFaceImage,
       'returnFullDocumentImage': instance.returnFullDocumentImage,
       'returnSignatureImage': instance.returnSignatureImage,

--- a/BlinkID/lib/recognizers/blink_id_recognizer.g.dart
+++ b/BlinkID/lib/recognizers/blink_id_recognizer.g.dart
@@ -40,9 +40,9 @@ Map<String, dynamic> _$BlinkIdRecognizerToJson(BlinkIdRecognizer instance) =>
       'faceImageDpi': instance.faceImageDpi,
       'fullDocumentImageDpi': instance.fullDocumentImageDpi,
       'fullDocumentImageExtensionFactors':
-          instance.fullDocumentImageExtensionFactors,
+          instance.fullDocumentImageExtensionFactors.toJson(),
       'paddingEdge': instance.paddingEdge,
-      'recognitionModeFilter': instance.recognitionModeFilter,
+      'recognitionModeFilter': instance.recognitionModeFilter.toJson(),
       'returnFaceImage': instance.returnFaceImage,
       'returnFullDocumentImage': instance.returnFullDocumentImage,
       'returnSignatureImage': instance.returnSignatureImage,

--- a/BlinkID/lib/recognizers/document_face_recognizer.g.dart
+++ b/BlinkID/lib/recognizers/document_face_recognizer.g.dart
@@ -29,7 +29,7 @@ Map<String, dynamic> _$DocumentFaceRecognizerToJson(
       'faceImageDpi': instance.faceImageDpi,
       'fullDocumentImageDpi': instance.fullDocumentImageDpi,
       'fullDocumentImageExtensionFactors':
-          instance.fullDocumentImageExtensionFactors,
+          instance.fullDocumentImageExtensionFactors.toJson(),
       'numStableDetectionsThreshold': instance.numStableDetectionsThreshold,
       'returnFaceImage': instance.returnFaceImage,
       'returnFullDocumentImage': instance.returnFullDocumentImage,

--- a/BlinkID/lib/recognizers/mrtd_combined_recognizer.g.dart
+++ b/BlinkID/lib/recognizers/mrtd_combined_recognizer.g.dart
@@ -36,7 +36,7 @@ Map<String, dynamic> _$MrtdCombinedRecognizerToJson(
       'faceImageDpi': instance.faceImageDpi,
       'fullDocumentImageDpi': instance.fullDocumentImageDpi,
       'fullDocumentImageExtensionFactors':
-          instance.fullDocumentImageExtensionFactors,
+          instance.fullDocumentImageExtensionFactors.toJson(),
       'numStableDetectionsThreshold': instance.numStableDetectionsThreshold,
       'returnFaceImage': instance.returnFaceImage,
       'returnFullDocumentImage': instance.returnFullDocumentImage,

--- a/BlinkID/lib/recognizers/mrtd_recognizer.g.dart
+++ b/BlinkID/lib/recognizers/mrtd_recognizer.g.dart
@@ -28,6 +28,6 @@ Map<String, dynamic> _$MrtdRecognizerToJson(MrtdRecognizer instance) =>
       'detectGlare': instance.detectGlare,
       'fullDocumentImageDpi': instance.fullDocumentImageDpi,
       'fullDocumentImageExtensionFactors':
-          instance.fullDocumentImageExtensionFactors,
+          instance.fullDocumentImageExtensionFactors.toJson(),
       'returnFullDocumentImage': instance.returnFullDocumentImage,
     };

--- a/BlinkID/lib/recognizers/passport_recognizer.g.dart
+++ b/BlinkID/lib/recognizers/passport_recognizer.g.dart
@@ -28,7 +28,7 @@ Map<String, dynamic> _$PassportRecognizerToJson(PassportRecognizer instance) =>
       'faceImageDpi': instance.faceImageDpi,
       'fullDocumentImageDpi': instance.fullDocumentImageDpi,
       'fullDocumentImageExtensionFactors':
-          instance.fullDocumentImageExtensionFactors,
+          instance.fullDocumentImageExtensionFactors.toJson(),
       'returnFaceImage': instance.returnFaceImage,
       'returnFullDocumentImage': instance.returnFullDocumentImage,
       'signResult': instance.signResult,

--- a/BlinkID/lib/recognizers/success_frame_grabber_recognizer.g.dart
+++ b/BlinkID/lib/recognizers/success_frame_grabber_recognizer.g.dart
@@ -17,5 +17,5 @@ Map<String, dynamic> _$SuccessFrameGrabberRecognizerToJson(
         SuccessFrameGrabberRecognizer instance) =>
     <String, dynamic>{
       'recognizerType': instance.recognizerType,
-      'slaveRecognizer': instance.slaveRecognizer,
+      'slaveRecognizer': instance.slaveRecognizer.toJson(),
     };

--- a/BlinkID/lib/recognizers/usdl_combined_recognizer.g.dart
+++ b/BlinkID/lib/recognizers/usdl_combined_recognizer.g.dart
@@ -29,7 +29,7 @@ Map<String, dynamic> _$UsdlCombinedRecognizerToJson(
       'returnFaceImage': instance.returnFaceImage,
       'returnFullDocumentImage': instance.returnFullDocumentImage,
       'fullDocumentImageExtensionFactors':
-          instance.fullDocumentImageExtensionFactors,
+          instance.fullDocumentImageExtensionFactors.toJson(),
       'numStableDetectionsThreshold': instance.numStableDetectionsThreshold,
       'signResult': instance.signResult,
     };

--- a/BlinkID/lib/recognizers/visa_recognizer.g.dart
+++ b/BlinkID/lib/recognizers/visa_recognizer.g.dart
@@ -25,7 +25,7 @@ Map<String, dynamic> _$VisaRecognizerToJson(VisaRecognizer instance) =>
       'faceImageDpi': instance.faceImageDpi,
       'fullDocumentImageDpi': instance.fullDocumentImageDpi,
       'fullDocumentImageExtensionFactors':
-          instance.fullDocumentImageExtensionFactors,
+          instance.fullDocumentImageExtensionFactors.toJson(),
       'returnFaceImage': instance.returnFaceImage,
       'returnFullDocumentImage': instance.returnFullDocumentImage,
     };


### PR DESCRIPTION
Added `explicit_to_json: true` option.

With this setting, generated toJson methods will explicitly call toJson on nested objects. This allows to simply write e.g. `collection.toJson()` instead of `jsonDecode(jsonEncode(collection))`.