### PR TITLE
fix: move stepTimeoutDuration to work as expected 

### DIFF
--- a/BlinkID/lib/blinkid_settings.dart
+++ b/BlinkID/lib/blinkid_settings.dart
@@ -76,11 +76,6 @@ class BlinkIdSessionSettings {
   /// Defines various parameters that control the scanning process.
   BlinkIdScanningSettings scanningSettings = BlinkIdScanningSettings();
 
-  /// Duration in seconds before scanning step times out and is cancelled.
-  /// If less than zero, scanning will not time out.
-  /// Defaults to 15.0
-  int stepTimeoutDuration = 15000;
-
   /// Represents the configuration settings for a scanning session.
   ///
   /// This class holds the settings related to the resources initialization,
@@ -400,11 +395,17 @@ class BlinkIdScanningUxSettings {
   /// Default: [PrefferedCamera.back]
   PreferredCamera preferredCamera = PreferredCamera.back;
 
+  /// Duration in seconds before scanning step times out and is cancelled.
+  /// If less than zero, scanning will not time out.
+  /// Defaults to 15.0
+  int stepTimeoutDuration = 15000;
+
   BlinkIdScanningUxSettings({
     this.allowHapticFeedback = true,
     this.showHelpButton = true,
     this.showOnboardingDialog = true,
     this.preferredCamera = PreferredCamera.back,
+    this.stepTimeoutDuration = 15000,
   });
 
   factory BlinkIdScanningUxSettings.fromJson(Map<String, dynamic> json) =>

--- a/BlinkID/lib/blinkid_settings.g.dart
+++ b/BlinkID/lib/blinkid_settings.g.dart
@@ -36,15 +36,13 @@ BlinkIdSessionSettings _$BlinkIdSessionSettingsFromJson(
       ..scanningMode = $enumDecode(_$ScanningModeEnumMap, json['scanningMode'])
       ..scanningSettings = BlinkIdScanningSettings.fromJson(
         json['scanningSettings'] as Map<String, dynamic>,
-      )
-      ..stepTimeoutDuration = (json['stepTimeoutDuration'] as num).toInt();
+      );
 
 Map<String, dynamic> _$BlinkIdSessionSettingsToJson(
   BlinkIdSessionSettings instance,
 ) => <String, dynamic>{
   'scanningMode': _$ScanningModeEnumMap[instance.scanningMode]!,
   'scanningSettings': instance.scanningSettings,
-  'stepTimeoutDuration': instance.stepTimeoutDuration,
 };
 
 const _$ScanningModeEnumMap = {
@@ -182,6 +180,7 @@ BlinkIdScanningUxSettings _$BlinkIdScanningUxSettingsFromJson(
   preferredCamera:
       $enumDecodeNullable(_$PreferredCameraEnumMap, json['preferredCamera']) ??
       PreferredCamera.back,
+  stepTimeoutDuration: (json['stepTimeoutDuration'] as num?)?.toInt() ?? 15000,
 );
 
 Map<String, dynamic> _$BlinkIdScanningUxSettingsToJson(
@@ -191,6 +190,7 @@ Map<String, dynamic> _$BlinkIdScanningUxSettingsToJson(
   'showOnboardingDialog': instance.showOnboardingDialog,
   'allowHapticFeedback': instance.allowHapticFeedback,
   'preferredCamera': _$PreferredCameraEnumMap[instance.preferredCamera]!,
+  'stepTimeoutDuration': instance.stepTimeoutDuration,
 };
 
 const _$PreferredCameraEnumMap = {


### PR DESCRIPTION
### Problem
During implementation of the Flutter BlinkID package, I noticed that the stepTimeoutDuration parameter had no effect on the actual timeout behavior. After debugging the Kotlin source files, I discovered that the timeout value was being incorrectly passed to BlinkIdSessionSettings instead of BlinkIdScanningUxSettings where it's actually used.

### Solution
Moved stepTimeoutDuration from BlinkIdSessionSettings to BlinkIdScanningUxSettings in the Dart layer
Updated the automatically generated file

### Testing
✅ Android: Verified working in my Flutter application
⚠️ iOS: Untested (no access to iOS development environment)

This change ensures the timeout parameter works as expected across platforms. Would appreciate if someone could verify the iOS implementation.