### PR TITLE
add new license key, and force deployment target to 16 for iOS

### DIFF
--- a/initBlinkIdFlutterSample.sh
+++ b/initBlinkIdFlutterSample.sh
@@ -49,15 +49,18 @@ s/<string>12\.0<\/string>/<string>16.0<\/string>/
 # Xcode project override
 sed -i '' 's/IPHONEOS_DEPLOYMENT_TARGET = [0-9.]*/IPHONEOS_DEPLOYMENT_TARGET = 16.0/' Runner.xcodeproj/project.pbxproj
 
-# xcconfig override
-sed -i '' 's/IPHONEOS_DEPLOYMENT_TARGET=[0-9.]*/IPHONEOS_DEPLOYMENT_TARGET=16.0/' Flutter/*.xcconfig
+# xcconfig override - append since Flutter-generated xcconfigs only contain an #include and have no existing entry to replace
+echo "IPHONEOS_DEPLOYMENT_TARGET=16.0" >> Flutter/Debug.xcconfig
+echo "IPHONEOS_DEPLOYMENT_TARGET=16.0" >> Flutter/Release.xcconfig
 
 # add the camera and photo usage descriptions into Info.plist as the BlinkID SDK requires it.
-sed -i '' '/<dict>/a\
-  <key>NSCameraUsageDescription</key>\
-  <string>Enable the camera usage for BlinkID default UX scanning</string>\
-  <key>NSPhotoLibraryUsageDescription</key>\
-  <string>Enable photo gallery usage for BlinkID DirectAPI scanning</string>\
+# Use '^<dict>$' to match only the root-level <dict> tag (no indentation), avoiding
+# insertion into nested dicts (UIApplicationSceneManifest, UISceneConfigurations, etc.).
+sed -i '' '/^<dict>$/a\
+\	<key>NSCameraUsageDescription</key>\
+\	<string>Enable the camera usage for BlinkID default UX scanning</string>\
+\	<key>NSPhotoLibraryUsageDescription</key>\
+\	<string>Enable photo gallery usage for BlinkID DirectAPI scanning</string>\
 ' Runner/Info.plist
 
 # update the config for iOS as the minimum target has been raised

--- a/sample_files/main.dart
+++ b/sample_files/main.dart
@@ -47,10 +47,10 @@ class _MyAppState extends State<MyApp> {
     /// A valid license key can be obtained from the Microblink Developer Hub, here: https://developer.microblink.com
     if (Platform.isAndroid) {
       sdkLicenseKey =
-          "sRwCABVjb20ubWljcm9ibGluay5zYW1wbGUAbGV5SkRjbVZoZEdWa1QyNGlPakUzTmpJeE56QTRNakF3TkRRc0lrTnlaV0YwWldSR2IzSWlPaUprWkdRd05qWmxaaTAxT0RJekxUUXdNRGd0T1RRNE1DMDFORFU0WWpBeFlUVTJZamdpZlE9PRpURkVPwuO0koYgtsId0UoOnkvZdrc5+ewfldLFcoG9SoE1NurAQ6fYusivk5aUxIRrbWM7ak7bZfr/Y8ud9ayh2GEgB96T6uufqumXoW22/XJDPAcU4Mp8uzbIjps=";
+          "sRwCABVjb20ubWljcm9ibGluay5zYW1wbGUAbGV5SkRjbVZoZEdWa1QyNGlPakUzTnpreE1ESXpOVGMxT1RBc0lrTnlaV0YwWldSR2IzSWlPaUprWkdRd05qWmxaaTAxT0RJekxUUXdNRGd0T1RRNE1DMDFORFU0WWpBeFlUVTJZamdpZlE9PRXlOs6VFBOfXCx1+6HuENpn05k2kl20pJr4kQ4S1sMxuSzZ+B8YhC9rYMsFXr3HSskFmMFwEe+44OQ1ZE2sm9iHUpxNBmVGpgBTKPOrc2vquGbpqmFwm1feyTL9Aw==";
     } else if (Platform.isIOS) {
       sdkLicenseKey =
-          "sRwCABVjb20ubWljcm9ibGluay5zYW1wbGUBbGV5SkRjbVZoZEdWa1QyNGlPakUzTmpJeE56QTROVE01Tnpnc0lrTnlaV0YwWldSR2IzSWlPaUprWkdRd05qWmxaaTAxT0RJekxUUXdNRGd0T1RRNE1DMDFORFU0WWpBeFlUVTJZamdpZlE9PYp8/JA4wSFGiNehLMfx8e5TtiIcdUR0YKx2/x/XlY+a10Qzw9Jsm/+aZS0QMqn14qrI6pmDxwkACGS4XkicR81ECuJIKtxe+7Tc/rLcmO2wjnFwuATJm69ERvdGDPw=";
+          "sRwCABVjb20ubWljcm9ibGluay5zYW1wbGUBbGV5SkRjbVZoZEdWa1QyNGlPakUzTnpreE56VTBNekE0T1Rrc0lrTnlaV0YwWldSR2IzSWlPaUprWkdRd05qWmxaaTAxT0RJekxUUXdNRGd0T1RRNE1DMDFORFU0WWpBeFlUVTJZamdpZlE9PaObKYfb4FlwqmqVoofXLicsmElmnSm1gmoXWaFx8MgdmmJRSLpdAfP6uV5xAr3K4rColEBYQ38GNh+FT081yjXPFB16LwdVhDiJcEK07cTBG5hQPXRy8+hoJJ1U7w==";
     }
 
     // If neccessary, the SDK can be pre-loaded with the neccessary resources before the scanning session starts.


### PR DESCRIPTION
- license keys are updated
- on iOS, even though the `IPHONEOS_DEPLOYMENT_TARGET ` was set to 16 in the `initBlinkIdFlutterSample.sh`, it was sometimes overridden to 13 during an Xcode build. added a fix that will always set this target to 16 for both debug and release variants
- sometimes duplicate entries were added to the generated `Info.plist` for iOS, causing the build to fail. Added a fix that should only add the (previously) duplicated entries at the root of the list, and not in nested levels as well

There are workarounds documented for the iOS issues - https://github.com/microblink/blinkid-flutter/blob/3fda4329785f79b5454fe8b2bddba07fb01f0264/README.md?plain=1#L67, and they should still be useful when a builds needs to be refreshed, so dependencies are fetched correctly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced iOS build configuration handling to consistently apply deployment target settings across Debug and Release configurations
  * Improved Info.plist configuration insertion mechanism to accurately target root-level dictionary entries while avoiding nested element conflicts
  * Updated BlinkID SDK license keys for both iOS and Android platforms

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/microblink/blinkid-flutter/pull/96?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->